### PR TITLE
improve description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ocrd_repair_inconsistencies
 
-Automatically fix PAGE-XML order inconsistencies in regions, lines and words.
-Children elements are only reordered if reordering by coordinates
-top-to-bottom/left-to-right fixes the appropriately concatenated `TextEquiv`
-texts of the children to match the parent's `TextEquiv` text. This processor
-does not change reading order, just the order of the XML elements in the file.
+Automatically re-order lines, words and glyphs to become textually consistent with their parents.
+
+PAGE-XML elements with textual annotation are re-ordered by their centroid coordinates
+in top-to-bottom/left-to-right fashion iff such re-ordering fixes the inconsistency
+between their appropriately concatenated `TextEquiv` texts with their parent's `TextEquiv` text.
+
+This processor does not affect `ReadingOrder` between regions, just the order of the XML elements below the region level, and only if not contradicting the annotated `textLineOrder`/`readingDirection`.
 
 We wrote this as a one-shot script to fix some files. Use with caution.
 

--- a/ocrd_repair_inconsistencies/ocrd-tool.json
+++ b/ocrd_repair_inconsistencies/ocrd-tool.json
@@ -1,11 +1,11 @@
 {
   "tools": {
-    "ocrd_repair_inconsistencies": {
-      "executable": "ocrd_repair_inconsistencies",
+    "ocrd-repair-inconsistencies": {
+      "executable": "ocrd-repair-inconsistencies",
       "categories": [
         "Layout analysis"
       ],
-      "description": "Repair glyph/word/line order inconsistencies",
+      "description": "Re-order glyphs/words/lines top-down-left-right when textually inconsistent with their parents",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK"
       ],
@@ -13,9 +13,9 @@
         "OCR-D-SEG-BLOCK-FIXED"
       ],
       "steps": [
-        "layout/segmentation/region",
         "layout/segmentation/line",
-        "layout/segmentation/words"
+        "layout/segmentation/word",
+        "layout/segmentation/glyph"
       ]
     }
   }


### PR DESCRIPTION
@mikegerber I tried to be more specific/detailed, because one really must understand the exact use-case.

As for the tool json, I removed step `"layout/segmentation/region"` because this does not change region ordering (which is also why it does not affect or relate to `ReadingOrder`), and replaced the underscores with hyphens as is more conventional. (But the tool could probably by named `ocrd-repair-ordering`.)

Feel free to c&p as you like.

I still think this would make a very good addition to `ocrd-segment-repair`...
