### PR TITLE
All orders

### DIFF
--- a/ocrd_repair_inconsistencies/cli.py
+++ b/ocrd_repair_inconsistencies/cli.py
@@ -1,7 +1,8 @@
 import click
 
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
-from ocrd_repair_inconsistencies.ocrd_repair_inconsistencies import RepairInconsistencies
+
+from .ocrd_repair_inconsistencies import RepairInconsistencies
 
 
 @click.command()

--- a/ocrd_repair_inconsistencies/ocrd_repair_inconsistencies.py
+++ b/ocrd_repair_inconsistencies/ocrd_repair_inconsistencies.py
@@ -37,22 +37,51 @@ class RepairInconsistencies(Processor):
             regions = page.get_TextRegion()
 
             for region in regions:
-                if region.readingDirection != 'left-to-right':
-                    LOG.info('Not processing region "%s" (not left-to-right)', region.id)
-                    continue
-                if len(region.get_TextLine()) > 1 and region.textLineOrder != 'top-to-bottom':
-                    LOG.info('Not processing region "%s" (not top-to-bottom)', region.id)
+                textLineOrder = 'top-to-bottom'
+                for segment in [region, page]:
+                    if segment.textLineOrder is None:
+                        continue
+                    else:
+                        textLineOrder = segment.textLineOrder
+                        break
+                if textLineOrder not in ['top-to-bottom', 'bottom-to-top']:
+                    LOG.info('Not processing page "%s" region "%s" (textLineOrder=%s)',
+                             page_id, region.id, textLineOrder)
                     continue
 
-                _fix_lines(region)
+                _fix_lines(region, page_id, reverse=textLineOrder=='bottom-to-top')
 
                 lines = region.get_TextLine()
                 for line in lines:
-                    _fix_words(line)
+                    readingDirection = 'left-to-right'
+                    for segment in [line, region, page]:
+                        if segment.readingDirection is None:
+                            continue
+                        else:
+                            readingDirection = segment.readingDirection
+                            break
+                    if readingDirection not in ['left-to-right', 'right-to-left']:
+                        LOG.info('Not processing page "%s" line "%s" (readingDirection=%s)',
+                                 page_id, line.id, readingDirection)
+                        continue
+                    
+                    _fix_words(line, page_id, reverse=readingDirection=='right-to-left')
 
                     words = line.get_Word()
                     for word in words:
-                        _fix_glyphs(word)
+                        readingDirection = 'left-to-right'
+                        for segment in [word, line, region, page]:
+                            if segment.readingDirection is None:
+                                continue
+                            else:
+                                readingDirection = segment.readingDirection
+                                break
+                        if readingDirection not in ['left-to-right', 'right-to-left']:
+                            LOG.info('Not processing page "%s" word "%s" (readingDirection=%s)',
+                                     page_id, word.id, readingDirection)
+                            continue
+
+                        _fix_glyphs(word, page_id, reverse=readingDirection=='right-to-left')
 
             file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
@@ -84,46 +113,73 @@ def get_text(thing, joiner=None):
     return text
 
 
-def _fix_words(line):
+def _fix_words(line, page_id, reverse=False):
     """Fix word order in a line"""
 
     words = line.get_Word()
+    if not words:
+        return
     line_text = get_text(line)
     words_text = get_text(words, ' ')
     if line_text != words_text:
-        sorted_words = sorted(words, key=lambda w: Polygon(polygon_from_points(w.get_Coords().points)).centroid.x)
+        sorted_words = sorted(words, reverse=reverse,
+                              key=lambda w: Polygon(polygon_from_points(w.get_Coords().points)).centroid.x)
         sorted_words_text = get_text(sorted_words, ' ')
 
         if sorted_words_text == line_text:
-            LOG.info('Fixing word order of line "%s"', line.id)
+            LOG.info('Fixing word order of page "%s" line "%s"', page_id, line.id)
             line.set_Word(sorted_words)
+        else:
+            LOG.debug('Resorting lines of page "%s" region "%s" from %s to %s does not suffice to turn "%s" into "%s"',
+                      page_id, line.id,
+                      str([word.id for word in words]),
+                      str([word.id for word in sorted_words]),
+                      words_text, line_text)
 
 
-def _fix_glyphs(word):
+def _fix_glyphs(word, page_id, reverse=False):
     """Fix glyph order in a word"""
 
     glyphs = word.get_Glyph()
+    if not glyphs:
+        return
     word_text = get_text(word)
     glyphs_text = get_text(glyphs, '')
     if word_text != glyphs_text:
-        sorted_glyphs = sorted(glyphs, key=lambda g: Polygon(polygon_from_points(g.get_Coords().points)).centroid.x)
+        sorted_glyphs = sorted(glyphs, reverse=reverse,
+                               key=lambda g: Polygon(polygon_from_points(g.get_Coords().points)).centroid.x)
         sorted_glyphs_text = get_text(sorted_glyphs, '')
 
         if sorted_glyphs_text == word_text:
-            LOG.info('Fixing glyph order of word "%s"', word.id)
+            LOG.info('Fixing glyph order of page "%s" word "%s"', page_id, word.id)
             word.set_Glyph(sorted_glyphs)
+        else:
+            LOG.debug('Resorting glyphs of page "%s" word "%s" from %s to %s does not suffice to turn "%s" into "%s"',
+                      page_id, word.id,
+                      str([glyph.id for glyph in glyphs]),
+                      str([glyph.id for glyph in sorted_glyphs]),
+                      glyphs_text, word_text)
 
 
-def _fix_lines(region):
+def _fix_lines(region, page_id, reverse=False):
     """Fix line order in a region"""
 
     lines = region.get_TextLine()
+    if not lines:
+        return
     region_text = get_text(region)
     lines_text = get_text(lines, '\n')
     if region_text != lines_text:
-        sorted_lines = sorted(lines, key=lambda l: Polygon(polygon_from_points(l.get_Coords().points)).centroid.y)
+        sorted_lines = sorted(lines, reverse=reverse,
+                              key=lambda l: Polygon(polygon_from_points(l.get_Coords().points)).centroid.y)
         sorted_lines_text = get_text(sorted_lines, '\n')
 
         if sorted_lines_text == region_text:
-            LOG.info('Fixing line order of region "%s"', region.id)
+            LOG.info('Fixing line order of page "%s" region "%s"', page_id, region.id)
             region.set_TextLine(sorted_lines)
+        else:
+            LOG.debug('Resorting lines of page "%s" region "%s" from %s to %s does not suffice to turn "%s" into "%s"',
+                      page_id, region.id,
+                      str([line.id for line in lines]),
+                      str([line.id for line in sorted_lines]),
+                      lines_text, region_text)


### PR DESCRIPTION
Fixes #3.

Also, now we can see the complementary problem of repairing non-conforming **tokenization**:

```
ocrd-repair-inconsistencies -m assets/data/kant_aufklaerung_1784/data/mets.xml -I OCR-D-GT-PAGE -O OCR-D-GT-PAGE-FIXED
12:29:31.191 INFO processor.RepairInconsistencies - INPUT FILE 0 / PHYS_0017
12:29:31.207 DEBUG processor.RepairInconsistencies - Resorting lines of page "PHYS_0017" region "tl_1" from ['w_w1aab1b1b2b1b1ab1', 'word_1478541234932_798', 'word_1478541234930_797'] to ['w_w1aab1b1b2b1b1ab1', 'word_1478541234932_798', 'word_1478541234930_797'] does not suffice to turn "Berliniſche Monatsſchrift ." into "Berliniſche Monatsſchrift."
12:29:31.207 DEBUG processor.RepairInconsistencies - Resorting lines of page "PHYS_0017" region "tl_4" from ['word_1478541284648_806', 'word_1478541284647_805'] to ['word_1478541284648_806', 'word_1478541284647_805'] does not suffice to turn "1 ." into "1."
12:29:31.208 DEBUG processor.RepairInconsistencies - Resorting lines of page "PHYS_0017" region "tl_5" from ['w_w1aab1b3b2b3b1ab1', 'w_w1aab1b3b2b3b1ac27', 'word_1478541289590_808', 'word_1478541289588_807'] to ['w_w1aab1b3b2b3b1ab1', 'w_w1aab1b3b2b3b1ac27', 'word_1478541289590_808', 'word_1478541289588_807'] does not suffice to turn "Beantwortung der Frage :" into "Beantwortung der Frage:"
12:29:31.208 DEBUG processor.RepairInconsistencies - Resorting lines of page "PHYS_0017" region "tl_6" from ['w_w1aab1b3b2b3b3ab1', 'w_w1aab1b3b2b3b3ab9', 'word_1478541293583_810', 'word_1478541293581_809'] to ['w_w1aab1b3b2b3b3ab1', 'w_w1aab1b3b2b3b3ab9', 'word_1478541293583_810', 'word_1478541293581_809'] does not suffice to turn "Was iſt Aufklaͤrung ?" into "Was iſt Aufklaͤrung?"
...
```

So, @mikegerber do you want me to integrate my tokenization repair [solution](https://github.com/OCR-D/ocrd_keraslm/blob/da105a8a8b68844389cd3e08307c05c9c6123350/ocrd_keraslm/wrapper/rate.py#L312) here as well? (Perhaps to be activated by an extra parameter?)